### PR TITLE
[TextArea] Set cursor position with mouse click

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
-# **Not your average crayon.**
+## **Not your average crayon.**
 
 ✏️ [https://lauraaubin.github.io/not-your-average-crayon](Try out this crayon) ✏️
 
+- Include snazzy screenshot here
+- Provide some amazing bio
+- Why do this?
+- Why not?
+
 <br>
 
-# 🛠 Development
+## 🛠 Development
 
-## *"😘 First time here?"*
+...
+
+## *"Hey there gorgeous, first time here? 😘"*
 
 <br>
 
 <details>
-<summary>😶 Maybe.</summary>
+<summary>Mmhmmm. 😶</summary>
 
 <hr>
 
@@ -29,6 +36,8 @@ $ npm install
 $ yarn build
 ```
 
+<br/>
+
 > **Note**
 > <small>You can skip `yarn build` if you will be exclusively pushing to Github Pages™️</small>
 
@@ -39,7 +48,7 @@ $ yarn build
 <br>
 
 <details>
-<summary>🤓 I'm a regular...</summary>
+<summary>I'm a regular... 🤓 </summary>
 
 <hr>
 

--- a/src/TextArea/TextArea.scss
+++ b/src/TextArea/TextArea.scss
@@ -1,18 +1,31 @@
-.TextArea {
-   color: black;
-   font-family: 'Helvetica', 'Perpetua';
+@mixin TextProperties {
+  // This value must match that used in useTextAreaContent
+  line-height: 15px;
 
-   outline: none;
-   border: none;
-   // overflow: auto;
-   /* textarea is inline and there is a gap at the bottom for it's descenders.
+  font-size: 14px;
+  color: black;
+  font-family: 'Helvetica', 'Perpetua';
+}
+
+.TextArea {
+  @include TextProperties;
+
+  outline: none;
+  border: none;
+  /* textarea is inline and there is a gap at the bottom for it's descenders.
       vertical-align: top removes this gap.
    */
-   vertical-align: top;
-   resize: none;
+  vertical-align: top;
+  resize: none;
 
-   height: 200px;
-   width: 400px;
+  width: 400px;
+  height: 200px;
 
-   box-shadow: 5px 5px lightslategray;
+  box-shadow: 5px 5px lightslategray;
+}
+
+.TextAreaDoppelganger {
+  @include TextProperties;
+
+  border: 1px red solid;
 }

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -1,7 +1,35 @@
-import React from 'react';
+import React, {useRef, ChangeEvent} from 'react';
+import {useMouseCoordinates, useTextAreaContent} from './hooks';
 
 import './TextArea.scss';
 
 export function TextArea() {
-  return <textarea className="TextArea" />;
+  const TextAreaRef = useRef<HTMLDivElement>(null);
+
+  const {mouseCoordinates, trackMouse} = useMouseCoordinates();
+  const {text, setText, doppelgangerText} = useTextAreaContent({
+    TextAreaRef,
+    mouseCoordinates,
+  });
+
+  function updateText({target: {value}}: ChangeEvent<HTMLTextAreaElement>) {
+    setText(value);
+  }
+
+  return (
+    <div>
+      <div style={{display: 'flex'}}>
+        <div ref={TextAreaRef} className="TextAreaDoppelganger">
+          {doppelgangerText}
+        </div>
+      </div>
+
+      <textarea
+        className="TextArea"
+        value={text}
+        onChange={updateText}
+        onMouseDown={trackMouse}
+      />
+    </div>
+  );
 }

--- a/src/TextArea/hooks/index.ts
+++ b/src/TextArea/hooks/index.ts
@@ -1,1 +1,2 @@
 export {useMouseCoordinates} from './use-mouse-coordinates';
+export {useTextAreaContent} from './use-text-area-content';

--- a/src/TextArea/hooks/index.ts
+++ b/src/TextArea/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useMouseCoordinates} from './use-mouse-coordinates';

--- a/src/TextArea/hooks/use-mouse-coordinates.ts
+++ b/src/TextArea/hooks/use-mouse-coordinates.ts
@@ -1,0 +1,16 @@
+import {useState, MouseEvent} from 'react';
+
+export function useMouseCoordinates() {
+  const [mouseCoordinates, setMouseCoordinates] = useState<{
+    x: number;
+    y: number;
+  }>();
+
+  function trackMouse({
+    nativeEvent: {offsetX: x, offsetY: y},
+  }: MouseEvent<HTMLTextAreaElement>) {
+    setMouseCoordinates({x, y});
+  }
+
+  return {mouseCoordinates, trackMouse};
+}

--- a/src/TextArea/hooks/use-text-area-content.ts
+++ b/src/TextArea/hooks/use-text-area-content.ts
@@ -1,31 +1,66 @@
 import {useState, useEffect} from 'react';
 
+// LINE_HEIGHT is also repeated in TextArea.scss
+const LINE_HEIGHT = 15;
+// Absolutely arbitrary
+const SPACE_WIDTH = 4;
+const NON_BREAKING_SPACE = String.fromCharCode(160);
+
 interface Props {
+  TextAreaRef: React.RefObject<HTMLDivElement>;
   mouseCoordinates?: {
     x: number;
     y: number;
   };
 }
 
-export function useTextAreaContent({mouseCoordinates}: Props) {
-  useEffect(() => {
-    function addNewRows() {
-      if (selectedRow > numberOfRows) {
-        const newRowsDelta = selectedRow - numberOfRows;
+export function useTextAreaContent({TextAreaRef, mouseCoordinates}: Props) {
+  const defaultText = 'Default';
+  const [text, setText] = useState<string>(defaultText);
+  const [doppelgangerText, setDoppelgangerText] = useState(defaultText);
 
-        setText(text + '\n'.repeat(newRowsDelta));
-      }
+  const {x, y} = mouseCoordinates ?? {};
+  const rowWidth = TextAreaRef?.current?.clientWidth;
+
+  useEffect(() => {
+    const height = getTextAreaHeight();
+    const selectedRow = getSelectedRow();
+
+    const newSpaces = countNewSpaces();
+
+    console.log('ADDING TEXT', {x, rowWidth, newSpaces});
+
+    if (newSpaces >= 1) {
+      addNewSpaces(newSpaces);
     }
 
-    addNewRows();
+    // if (selectedRow > height) {
+    //   console.log('new rows', {newRows});
+    //   setText((current) => current + '\n'.repeat(newRows));
+    // }
+
+    // addNewRows();
   }, [mouseCoordinates]);
 
-  const [text, setText] = useState<string>('Default txt');
+  useEffect(() => {
+    setDoppelgangerText(text);
+  }, [text]);
 
-  const selectedRow = mouseCoordinates?.y
-    ? Number((mouseCoordinates?.y / 15).toFixed())
-    : 1;
-  const numberOfRows = text.split('\n').length;
+  function getTextAreaHeight() {
+    return text.split('\n').length;
+  }
 
-  return {text, setText};
+  function getSelectedRow() {
+    return y ? Number((y / LINE_HEIGHT).toFixed()) : 1;
+  }
+
+  function countNewSpaces() {
+    return (x! - rowWidth!) / SPACE_WIDTH;
+  }
+
+  function addNewSpaces(spaces: number) {
+    setText(text + NON_BREAKING_SPACE.repeat(spaces));
+  }
+
+  return {text, setText, doppelgangerText};
 }

--- a/src/TextArea/hooks/use-text-area-content.ts
+++ b/src/TextArea/hooks/use-text-area-content.ts
@@ -1,0 +1,31 @@
+import {useState, useEffect} from 'react';
+
+interface Props {
+  mouseCoordinates?: {
+    x: number;
+    y: number;
+  };
+}
+
+export function useTextAreaContent({mouseCoordinates}: Props) {
+  useEffect(() => {
+    function addNewRows() {
+      if (selectedRow > numberOfRows) {
+        const newRowsDelta = selectedRow - numberOfRows;
+
+        setText(text + '\n'.repeat(newRowsDelta));
+      }
+    }
+
+    addNewRows();
+  }, [mouseCoordinates]);
+
+  const [text, setText] = useState<string>('Default txt');
+
+  const selectedRow = mouseCoordinates?.y
+    ? Number((mouseCoordinates?.y / 15).toFixed())
+    : 1;
+  const numberOfRows = text.split('\n').length;
+
+  return {text, setText};
+}


### PR DESCRIPTION
Closes https://github.com/LauraAubin/not-your-average-crayon/issues/2

### What does this accomplish?

This PR implements a regular `<textarea />` with the ability to click anywhere within the space to place the cursor. This allows you to bypass new lines and unchartered area so that you can start typing without the need to mash your space bar.

### How is this done?

Setting the cursor in the y-axis requires us to use a consistent `line-height` CSS property and perform a quick calculation using the clicked y-coordinate to determine which line we are on:


```js
  const selectedRow = mouseCoordinates?.y ? Number((mouseCoordinates?.y / 15).toFixed()) : 1;
```

We then add more new lines to the text area's state using `\n` if the clicked space is outside the bounds of our existing content. The cursor will automatically be placed on the last line.

In order to set the cursor in the x-axis,